### PR TITLE
Sorting category upgrade + fix for issue #68

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "world-anvil",
   "title": "World Anvil Integration",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "<p>A module to integrate <a href=\"https://worldanvil.com\" title=\"World Anvil\" target=\"_blank\">World Anvil</a> with Foundry Virtual Tabletop.</p>",
   "authors": [
     {
@@ -15,12 +15,11 @@
   ],
 	"compatibility": {
 		"minimum": "10",
-		"verified": "10",
-		"maximum": "10"
+		"verified": "11"
 	},
   "url": "https://github.com/foundryvtt/world-anvil",
   "manifest": "https://raw.githubusercontent.com/foundryvtt/world-anvil/master/module.json",
-  "download": "https://github.com/foundryvtt/world-anvil/archive/refs/tags/release-1.4.2.zip",
+  "download": "https://github.com/foundryvtt/world-anvil/archive/refs/tags/release-1.4.3.zip",
   "esmodules": ["wa.js"],
   "styles": ["wa.css"],
   "languages": [

--- a/module/framework.js
+++ b/module/framework.js
@@ -609,7 +609,11 @@ async function _getCategories({cache=true}={}) {
 
   // Third loop : Put the ones without parent as root children
   root.children = reqCategories.filter( c => !c.parent );
-  root.children.sort( (a,b) => a.title.localeCompare(b.title));
+  root.children.sort( (a,b) => {
+    const titleA = a.title ?? "";
+    const titleB = b.title ?? "";
+    return titleA.localeCompare(titleB);
+  });
   root.children.push(uncategorized);
   root.children.forEach( child => {
     child.parent = root;

--- a/module/framework.js
+++ b/module/framework.js
@@ -565,8 +565,10 @@ async function _getCategories({cache=true}={}) {
     id: CATEGORY_ID.root,
     title:  `[WA] ${anvil.world.name}`,
     position: 0,
-    copyForSort: [],
+    articles: [],
+    articleIds: [],
     children: [],
+    childrenIds: [],
     folder: null
   };
   categories.set(root.id, root);
@@ -576,44 +578,42 @@ async function _getCategories({cache=true}={}) {
     id: CATEGORY_ID.uncategorized,
     title: game.i18n.localize('WA.CategoryUncategorized'),
     position: 9e9,
-    copyForSort: [],
-    children : [],
-    parent: root,
+    articles: [],
+    articleIds: [],
+    children: [],
+    childrenIds: [],
     isUncategorized: true
   };
   categories.set(uncategorized.id, uncategorized);
 
   // Retrieve categories from the World Anvil API (build map)
   const request = await anvil.getCategories();
-  for ( let c of (request?.categories || []) ) {
+  
+  // First loop : subrequests
+  const reqCategories = (request?.categories || []);
+  for ( let c of reqCategories ) {
     categories.set(c.id, c);
-    c.copyForSort = c.children?.categories ?? [];
-    c.children = [];
-    c.parentCategoryId = c.parent?.id;
-    c.parent = undefined;
-    c.folder = undefined;
+    const subrequest = await anvil._fetch(`category/${c.id}`);
+    c.articles = [];
+    c.articleIds = (subrequest.articles ?? []).map( c => c.id );
+    c.childrenIds = (subrequest.children ?? []).map( c => c.id );
   }
-  // Append children
-  for( let c of (request?.categories || []) ) {
-    const parentId = c.parentCategoryId ?? CATEGORY_ID.root;
-    const parent = categories.get(parentId) ?? root;
-    c.parent = parent;
-    parent.children.push(c);
-  }
-  // Sort children
-  for( let c of categories.values() ) {
 
-    c.children.sort( (a,b) => {
-      const indexA = c.copyForSort.findIndex( cc => cc.id === a.id );
-      const indexB = c.copyForSort.findIndex( cc => cc.id === b.id );
-      const substr = indexA - indexB;
-      if( substr != 0 ) { return substr; }
-      return a.title.localeCompare(b.title);
+  // Second loop : Set category.children
+  for ( let c of reqCategories ) {
+    c.children = c.childrenIds.map( id => categories.get(id) );
+    c.children.forEach( child => {
+      child.parent = c;
     });
-    c.copyForSort = undefined;
   }
-  root.children.push(uncategorized);
 
+  // Third loop : Put the ones without parent as root children
+  root.children = reqCategories.filter( c => !c.parent );
+  root.children.sort( (a,b) => a.title.localeCompare(b.title));
+  root.children.push(uncategorized);
+  root.children.forEach( child => {
+    child.parent = root;
+  });
   return categories;
 }
 

--- a/module/framework.js
+++ b/module/framework.js
@@ -589,14 +589,14 @@ async function _getCategories({cache=true}={}) {
   // Retrieve categories from the World Anvil API (build map)
   const request = await anvil.getCategories();
   
-  // First loop : subrequests
+  // First loop : add id listings and store in map
   const reqCategories = (request?.categories || []);
   for ( let c of reqCategories ) {
     categories.set(c.id, c);
-    const subrequest = await anvil._fetch(`category/${c.id}`);
+    c.articleIds = (c.articles ?? []).map( a => a.id );
+    c.childrenIds = (c.children ?? []).map( ch => ch.id );
     c.articles = [];
-    c.articleIds = (subrequest.articles ?? []).map( c => c.id );
-    c.childrenIds = (subrequest.children ?? []).map( c => c.id );
+    c.children = [];
   }
 
   // Second loop : Set category.children

--- a/module/journal.js
+++ b/module/journal.js
@@ -135,7 +135,11 @@ export default class WorldAnvilBrowser extends Application {
       
       // Some may not be referenced (created after)
       const unreferencedArticles = category.unsortedArticles.filter(a => !category.articles.find( a2 => a == a2) );
-      unreferencedArticles.sort( (a,b) => a.title.localeCompare(b.title) );
+      unreferencedArticles.sort( (a,b) => {
+        const titleA = a.title ?? "";
+        const titleB = b.title ?? "";
+        return titleA.localeCompare(titleB);
+      });
       category.articles.push(...unreferencedArticles);
     }
     return contentTree;


### PR DESCRIPTION
Sorting category upgrade
------------------------------
We did have an issue with WA API last on 11/06/2023
After talking with Gorkam, he fixed it so that it could work as before.

But during the talk, he explained me that he also added more information inside fall article retrieval.
We now have the order of the articles contained in each category without having to make additional calls to the API !
So I integrated those data into our import process.

Fix for issue #68
------------------------------
I don't know why, but it seems that people can have articles without titles => I've added a check when sorting the article list.
